### PR TITLE
refactor!: move from node-tap to node test runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16, 18, 20]
+        node-version: [18, 20]
         redis-tag: [5, 6]
     services:
       redis:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "format": "prettier --write \"./src/**/*.{ts,js}\"",
     "lint": "npm run format && eslint . --ext .js,.ts --ignore-path .gitignore",
-    "test": "npm run lint && c8 -c ./src/tests/config/c8.json tap --rcfile=./src/tests/config/tap.yml ./src/tests/**/*.test.ts",
+    "test": "npm run lint && node --loader ts-node/esm --test ./src/tests/**",
     "build:cjs": "tsc --project tsconfig.cjs.json",
     "build:esm": "tsc --project tsconfig.esm.json",
     "build:browser": "esbuild --bundle --sourcemap --target=es2019 --format=esm --outfile=./dist/client/index.js ./src/index.ts",
@@ -50,7 +50,6 @@
     "@types/tap": "^15.0.9",
     "@typescript-eslint/eslint-plugin": "^6.8.0",
     "@typescript-eslint/parser": "^6.8.0",
-    "c8": "^7.14.0",
     "cronometro": "^1.1.5",
     "esbuild": "^0.19.4",
     "eslint": "^8.51.0",
@@ -58,7 +57,6 @@
     "ioredis": "^5.3.2",
     "prettier": "^3.0.3",
     "rimraf": "^5.0.5",
-    "tap": "^16.3.9",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2"
   },

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,81 +1,107 @@
-import {CreateCacheOptions, OptionsMemory, OptionsRedis, ValidatedCacheOptions} from "async-cache-dedupe"
+import {CreateCacheOptions, OptionsMemory, OptionsRedis, StorageType, ValidatedCacheOptions} from "async-cache-dedupe"
 
-export function validateOptions(options: CreateCacheOptions): ValidatedCacheOptions {
-  const validated = options
+export function validateOptions<T extends CreateCacheOptions>(options: T): ValidatedCacheOptions<Extract<T["storage"], {type: StorageType}>["type"]> {
+  let validated: CreateCacheOptions = {...options}
 
-  // TTL validation number and greater than 0
-  if (validated.ttl !== undefined && (validated.ttl < 0 || typeof validated.ttl !== "number")) {
-    throw new Error("ttl must be greater than 0")
-  } else if (validated.ttl === undefined) {
-    validated.ttl = 60
+  validated = validateTTL(validated)
+  validated = validateStale(validated)
+  validated = validateFunctionProperties(validated)
+  validated = validateStorage(validated)
+
+  return validated as ValidatedCacheOptions<Extract<T["storage"], {type: StorageType}>["type"]>
+}
+
+function validateTTL(options: CreateCacheOptions): CreateCacheOptions {
+  return {
+    ...options,
+    ttl: ensureNumberAndPositive(options.ttl, "ttl", 60)
   }
+}
 
-  // Stale validation number and greater than 0
-  if (validated.stale !== undefined && (validated.stale < 0 || typeof validated.stale !== "number")) {
-    throw new Error("stale must be greater than 0")
+function validateStale(options: CreateCacheOptions): CreateCacheOptions {
+  return {
+    ...options,
+    stale: ensureNumberAndPositive(options.stale, "stale", 60)
   }
+}
 
-  // onDedupe validation
-  if (options.onDedupe && typeof options.onDedupe !== "function") {
-    throw new Error("onDedupe must be a function")
-  }
+function validateFunctionProperties(options: CreateCacheOptions): CreateCacheOptions {
+  const functionProperties: (keyof CreateCacheOptions)[] = ["onDedupe", "onError", "onHit", "onMiss"]
 
-  // onError validation
-  if (options.onError && typeof options.onError !== "function") {
-    throw new Error("onError must be a function")
-  }
-
-  // onHit validation
-  if (options.onHit && typeof options.onHit !== "function") {
-    throw new Error("onHit must be a function")
-  }
-
-  // onMiss validation
-  if (options.onMiss && typeof options.onMiss !== "function") {
-    throw new Error("onMiss must be a function")
-  }
-
-  // Storage validation
-  if (options.storage) {
-    if (options.storage.type === "memory") {
-      const optionsMemory = options.storage.options as OptionsMemory
-
-      if (optionsMemory) {
-        if (optionsMemory.size && optionsMemory.size < 0) {
-          throw new Error("storage.options.size must be greater than 0")
-        }
-      } else if (!optionsMemory) {
-        validated.storage = {
-          type: "memory",
-          options: {
-            size: 1000
-          }
-        }
-      }
-    } else if (options.storage.type === "redis") {
-      const optionsRedis = options.storage.options as OptionsRedis
-
-      if (optionsRedis) {
-        if (!optionsRedis.client || (optionsRedis.client && typeof optionsRedis.client !== "object")) {
-          throw new Error("storage.options.client is required")
-        }
-
-        if (optionsRedis.invalidation && typeof optionsRedis.invalidation === "object") {
-          if (typeof optionsRedis.invalidation.invalidate !== "boolean") {
-            throw new Error("storage.options.invalidation.invalidate must be a boolean")
-          }
-
-          if (typeof optionsRedis.invalidation.referencesTTL === "number" && optionsRedis.invalidation.referencesTTL < 0) {
-            throw new Error("storage.options.invalidation.referencesTTL must be greater than 0")
-          }
-        }
-      } else {
-        throw new Error("storage.options must be defined")
-      }
-    } else {
-      throw new Error("storage.type must be memory or redis")
+  for (const prop of functionProperties) {
+    if (options[prop] && typeof options[prop] !== "function") {
+      throw new Error(`${prop} must be a function`)
     }
   }
 
-  return validated as ValidatedCacheOptions
+  return options
+}
+
+function validateStorage(options: CreateCacheOptions): CreateCacheOptions {
+  if (!options.storage) {
+    return {...options, storage: {type: "memory", options: {size: 1000}}}
+  } else if (options.storage.type === "memory") {
+    return {
+      ...options,
+      storage: {
+        ...options.storage,
+        options: validateMemoryStorage(options.storage.options)
+      }
+    }
+  } else if (options.storage.type === "redis") {
+    return {
+      ...options,
+      storage: {
+        ...options.storage,
+        options: validateRedisStorage(options.storage.options)
+      }
+    }
+  } else {
+    throw new Error("storage.type must be memory or redis")
+  }
+}
+
+function validateMemoryStorage(optionsMemory?: OptionsMemory): OptionsMemory {
+  const defaultOptions: OptionsMemory = {size: 1000}
+  const resultOptions = optionsMemory ?? defaultOptions
+
+  if (!resultOptions.size || typeof resultOptions.size !== "number") {
+    throw new Error("storage.options.size must be a number")
+  } else if (resultOptions.size && resultOptions.size < 0) {
+    throw new Error("storage.options.size must be greater than 0")
+  }
+  return resultOptions
+}
+
+function validateRedisStorage(optionsRedis: OptionsRedis): OptionsRedis {
+  if (!optionsRedis) {
+    throw new Error("storage.options must be defined")
+  }
+
+  if (!optionsRedis.client || typeof optionsRedis.client !== "object") {
+    throw new Error("storage.options.client is required")
+  }
+  if (typeof optionsRedis.invalidation !== "boolean") {
+    if (optionsRedis.invalidation && typeof optionsRedis.invalidation.invalidate !== "boolean") {
+      throw new Error("storage.options.invalidation.invalidate must be a boolean")
+    }
+
+    ensureNumberAndPositive(optionsRedis.invalidation?.referencesTTL, "storage.options.invalidation.referencesTTL", 60)
+  }
+  return optionsRedis
+}
+
+function ensureNumberAndPositive(value: unknown, propertyName: string, defaultValue?: number): number {
+  let resultValue = value
+  if (resultValue === undefined && defaultValue !== undefined) {
+    resultValue = defaultValue
+  }
+
+  if (typeof resultValue !== "number") {
+    throw new Error(`${propertyName} must be a number`)
+  } else if (resultValue < 0) {
+    throw new Error(`${propertyName} must be greater than 0`)
+  }
+
+  return resultValue
 }

--- a/src/tests/storage-redis.test.ts
+++ b/src/tests/storage-redis.test.ts
@@ -1,35 +1,66 @@
-import {test, teardown} from "tap"
-
+import test from "node:test"
+import assert from "node:assert"
+import {promisify} from "node:util"
 import {create, insert} from "@orama/orama"
 import {createOramaCache} from "../index.js"
 import Redis from "ioredis"
 
+const sleep = promisify(setTimeout)
+
 const redisClient = new Redis()
 
-teardown(async () => {
-  await redisClient.quit()
-})
-
-test("orama cache with redis storage", async t => {
-  t.plan(1)
-
-  const db = await create({
-    schema: {name: "string"}
+test.describe("redis storage", () => {
+  test.after(async () => {
+    await redisClient.quit()
   })
 
-  const cache = await createOramaCache(db, {
-    storage: {
-      type: "redis",
-      options: {
-        client: redisClient
+  test.it("should use redis storage", async () => {
+    const db = await create({
+      schema: {name: "string"}
+    })
+
+    const cache = await createOramaCache(db, {
+      storage: {
+        type: "redis",
+        options: {
+          client: redisClient
+        }
       }
-    }
+    })
+
+    await insert(db, {name: "foo"} as never)
+
+    const results = await cache.search({term: "foo"})
+    const resultsCached = await cache.search({term: "foo"})
+
+    assert.deepStrictEqual(results, resultsCached)
   })
 
-  await insert(db, {name: "foo"} as never)
+  test.skip("should invalidate with referencesTTL", async () => {
+    // test.plan(2)
+    const db = await create({
+      schema: {name: "string"}
+    })
 
-  const results = await cache.search({term: "foo"})
-  const resultsCached = await cache.search({term: "foo"})
+    const cache = await createOramaCache(db, {
+      storage: {
+        type: "redis",
+        options: {
+          client: redisClient,
+          invalidation: {
+            invalidate: true,
+            referencesTTL: 1 // 1 minute
+          }
+        }
+      }
+    })
 
-  t.same(results, resultsCached)
+    await insert(db, {name: "aaa"} as never)
+
+    await cache.search({term: "aaa"})
+    await sleep(60_000)
+
+    const keys = await redisClient.keys("*")
+    assert.deepStrictEqual(keys, [])
+  })
 })

--- a/src/tests/validation.test.ts
+++ b/src/tests/validation.test.ts
@@ -1,151 +1,173 @@
-import {CreateCacheOptions, OptionsMemory, ValidatedCacheOptions} from "async-cache-dedupe"
-import {test} from "tap"
+import test from "node:test"
+import assert from "node:assert"
+import {CreateCacheOptions} from "async-cache-dedupe"
 import {validateOptions} from "../lib/validation.js"
 
-test("should validate ttl", ({plan, throws}) => {
-  plan(1)
-
-  const options = {ttl: -1} as CreateCacheOptions
-  throws(() => {
-    validateOptions(options)
-  }, "ttl must be greater than 0")
-})
-
-test("should validate stale", ({plan, throws}) => {
-  plan(2)
-
-  const options = {stale: -1} as CreateCacheOptions
-  throws(() => {
-    validateOptions(options)
-  }, "stale must be greater than 0")
-
-  // @ts-expect-error - stale is a number
-  const options2 = {stale: "foo"} as CreateCacheOptions
-  throws(() => {
-    validateOptions(options2)
-  }, "stale must be greater than 0")
-})
-
-test("should validate onDedupe", ({plan, throws}) => {
-  plan(1)
-
-  // @ts-expect-error - onDedupe is a function
-  const options = {onDedupe: "foo"} as CreateCacheOptions
-  throws(() => {
-    validateOptions(options)
-  }, "onDedupe must be a function")
-})
-
-test("should validate onError", ({plan, throws}) => {
-  plan(1)
-
-  // @ts-expect-error - onError is a function
-  const options = {onError: "foo"} as CreateCacheOptions
-  throws(() => {
-    validateOptions(options)
-  }, "onError must be a function")
-})
-
-test("should validate onHit", ({plan, throws}) => {
-  plan(1)
-
-  // @ts-expect-error - onHit is a function
-  const options = {onHit: "foo"} as CreateCacheOptions
-  throws(() => {
-    validateOptions(options)
-  }, "onHit must be a function")
-})
-
-test("should validate onMiss", ({plan, throws}) => {
-  plan(1)
-
-  // @ts-expect-error - onMiss is a function
-  const options = {onMiss: "foo"} as CreateCacheOptions
-  throws(() => {
-    validateOptions(options)
-  }, "onMiss must be a function")
-})
-
-test("should validate storage", async () => {
-  test("should validate storage type", async ({plan, throws}) => {
-    plan(1)
-
-    // @ts-expect-error - storage is memory or redis
-    const options = {storage: {type: "foo"}} as CreateCacheOptions
-    throws(() => {
-      validateOptions(options)
-    }, "storage.type must be memory or redis")
-  })
-
-  // memory storage tests
-  test("should validate memory storage", async () => {
-    test("should set default size as 1000", async ({plan, same}) => {
-      plan(1)
-
-      const options = {storage: {type: "memory"}} as CreateCacheOptions
-      const validatedOptions = validateOptions(options) as ValidatedCacheOptions
-      same((validatedOptions?.storage.options as OptionsMemory).size, 1000)
+test.describe("validate options", () => {
+  test.describe("ttl", () => {
+    test.it("should throw if ttl is a negative number", () => {
+      const options = {ttl: -1} as CreateCacheOptions
+      assert.throws(() => validateOptions(options), {message: /ttl must be greater than 0/})
     })
 
-    test("should throw if size is less than 0", async ({plan, throws}) => {
-      plan(1)
-
-      const options = {storage: {type: "memory", options: {size: -1}}} as CreateCacheOptions
-      throws(() => {
-        validateOptions(options)
-      }, "storage.options.size must be greater than 0")
+    test.it("should throw if ttl is not a number", () => {
+      // @ts-expect-error - test invalid type
+      const options = {ttl: "foo"} as CreateCacheOptions
+      assert.throws(() => validateOptions(options), {message: /ttl must be a number/})
     })
   })
 
-  // redis storage tests
-  test("should validate redis storage", async () => {
-    test("should validate redis storage client", async ({plan, throws}) => {
-      plan(1)
-
-      // @ts-expect-error - client is an object
-      const options = {storage: {type: "redis", options: {client: "foo"}}} as CreateCacheOptions
-      throws(() => {
-        validateOptions(options)
-      }, "storage.options.client is required")
+  test.describe("stale", () => {
+    test.it("should throw if stale is a negative number", () => {
+      const options = {stale: -1} as CreateCacheOptions
+      assert.throws(() => validateOptions(options), {message: /stale must be greater than 0/})
     })
 
-    test("should validate redis storage invalidation", async () => {
-      test("should throw if options are not defined", async ({plan, throws}) => {
-        plan(1)
+    test.it("should throw if stale is not a number", () => {
+      // @ts-expect-error - test invalid type
+      const options = {stale: "foo"} as CreateCacheOptions
+      assert.throws(() => validateOptions(options), {message: /stale must be a number/})
+    })
+  })
 
+  test.describe("onDedupe", () => {
+    test.it("should throw if onDedupe is not a function", () => {
+      // @ts-expect-error - test invalid type
+      const options = {onDedupe: "foo"} as CreateCacheOptions
+      assert.throws(() => validateOptions(options), {message: /onDedupe must be a function/})
+    })
+
+    test.it("should not throw if onDedupe is a function", () => {
+      const options = {onDedupe: () => {}} as CreateCacheOptions
+      assert.doesNotThrow(() => validateOptions(options))
+    })
+  })
+
+  test.describe("onError", () => {
+    test.it("should throw if onError is not a function", () => {
+      // @ts-expect-error - test invalid type
+      const options = {onError: "foo"} as CreateCacheOptions
+      assert.throws(() => validateOptions(options), {message: /onError must be a function/})
+    })
+
+    test.it("should not throw if onError is a function", () => {
+      const options = {onError: () => {}} as CreateCacheOptions
+      assert.doesNotThrow(() => validateOptions(options))
+    })
+  })
+
+  test.describe("onHit", () => {
+    test.it("should throw if onHit is not a function", () => {
+      // @ts-expect-error - test invalid type
+      const options = {onHit: "foo"} as CreateCacheOptions
+      assert.throws(() => validateOptions(options), {message: /onHit must be a function/})
+    })
+
+    test.it("should not throw if onHit is a function", () => {
+      const options = {onHit: () => {}} as CreateCacheOptions
+      assert.doesNotThrow(() => validateOptions(options))
+    })
+  })
+
+  test.describe("onMiss", () => {
+    test.it("should throw if onMiss is not a function", () => {
+      // @ts-expect-error - test invalid type
+      const options = {onMiss: "foo"} as CreateCacheOptions
+      assert.throws(() => validateOptions(options), {message: /onMiss must be a function/})
+    })
+
+    test.it("should not throw if onMiss is a function", () => {
+      const options = {onMiss: () => {}} as CreateCacheOptions
+      assert.doesNotThrow(() => validateOptions(options))
+    })
+  })
+
+  test.describe("storage", () => {
+    test.it("should throw if storage.type is not memory or redis", () => {
+      // @ts-expect-error - test invalid type
+      const options = {storage: {type: "foo"}} as CreateCacheOptions
+      assert.throws(() => validateOptions(options), {message: /storage.type must be memory or redis/})
+    })
+
+    test.describe("memory", () => {
+      test.it("should not throw if storage.type is memory", () => {
+        const options = {storage: {type: "memory"}} as CreateCacheOptions
+        assert.doesNotThrow(() => validateOptions(options))
+      })
+
+      test.it("should throw if storage.type is memory and storage.options.size is a negative number", () => {
+        const options = {storage: {type: "memory", options: {size: -1}}} as CreateCacheOptions
+        assert.throws(() => validateOptions(options), {message: /storage.options.size must be greater than 0/})
+      })
+
+      test.it("should throw if storage.type is memory and storage.options.size is not a number", () => {
+        // @ts-expect-error - test invalid type
+        const options = {storage: {type: "memory", options: {size: "foo"}}} as CreateCacheOptions
+        assert.throws(() => validateOptions(options), {message: /storage.options.size must be a number/})
+      })
+
+      test.describe("size", () => {
+        test.it("should set storage.options.size to 1000 if not defined", () => {
+          const options = {storage: {type: "memory"}} as const
+          const validated = validateOptions(options)
+          assert.strictEqual(validated.storage.options.size, 1000)
+        })
+
+        test.it("should throw if storage.type is memory and storage.options.size is a negative number", () => {
+          const options = {storage: {type: "memory", options: {size: -1}}} as CreateCacheOptions
+          assert.throws(() => validateOptions(options), {message: /storage.options.size must be greater than 0/})
+        })
+      })
+    })
+
+    test.describe("redis", () => {
+      test.it("should not throw if storage.type is redis with options", () => {
+        const options = {storage: {type: "redis", options: {client: {}}}} as unknown as CreateCacheOptions
+        assert.doesNotThrow(() => validateOptions(options))
+      })
+
+      test.it("should throw if storage.type is redis without options", () => {
         const options = {storage: {type: "redis"}} as CreateCacheOptions
-        throws(() => {
-          validateOptions(options)
-        }, "storage.options.invalidation must be defined")
+        assert.throws(() => validateOptions(options), {message: /storage.options must be defined/})
       })
 
-      test("should throw if invalidate is not a boolean", async ({plan, throws}) => {
-        plan(1)
-
-        // @ts-expect-error - invalidate is a boolean
-        const options = {storage: {type: "redis", options: {client: {}, invalidation: {invalidate: "foo"}}}} as CreateCacheOptions
-        throws(() => {
-          validateOptions(options)
-        }, "storage.options.invalidation must be a boolean")
+      test.it("should throw if storage.type is redis and storage.options is not defined", () => {
+        const options = {storage: {type: "redis"}} as CreateCacheOptions
+        assert.throws(() => validateOptions(options), {message: /storage.options must be defined/})
       })
 
-      test("should throw if referencesTTL is less than 0", async ({plan, throws}) => {
-        plan(1)
-
-        const options = {storage: {type: "redis", options: {client: {}, invalidation: {invalidate: false, referencesTTL: -1}}}} as CreateCacheOptions
-        throws(() => {
-          validateOptions(options)
-        }, "storage.options.invalidation.referencesTTL must be greater than 0")
+      test.it("should throw if storage.type is redis and storage.options.client is not defined", () => {
+        const options = {storage: {type: "redis", options: {}}} as CreateCacheOptions
+        assert.throws(() => validateOptions(options), {message: /storage.options.client is required/})
       })
 
-      test("should throw if client is not an object", async ({plan, throws}) => {
-        plan(1)
+      test.describe("invalidation", () => {
+        test.it("should throw if storage.type is redis and storage.options.invalidation.invalidate is not set", () => {
+          const options = {storage: {type: "redis", options: {client: {}, invalidation: {}}}} as CreateCacheOptions
+          assert.throws(() => validateOptions(options), {message: /storage.options.invalidation.invalidate must be a boolean/})
+        })
 
-        // @ts-expect-error - client is not defined
-        const options = {storage: {type: "redis", options: {client: undefined}}} as CreateCacheOptions
-        throws(() => {
-          validateOptions(options)
-        }, "storage.options.client is required")
+        test.it("should throw if storage.type is redis and storage.options.invalidation.invalidate is not a boolean", () => {
+          // @ts-expect-error - test invalid type
+          const options = {storage: {type: "redis", options: {client: {}, invalidation: {invalidate: -1}}}} as CreateCacheOptions
+          assert.throws(() => validateOptions(options), {message: /storage.options.invalidation.invalidate must be a boolean/})
+        })
+
+        test.it("should throw if storage.type is redis and storage.options.invalidation.referencesTTL is not a number", () => {
+          // @ts-expect-error - test invalid type
+          const options = {storage: {type: "redis", options: {client: {}, invalidation: {invalidate: true, referencesTTL: "foo"}}}} as CreateCacheOptions
+          assert.throws(() => validateOptions(options), {message: /storage.options.invalidation.referencesTTL must be a number/})
+        })
+
+        test.it("should throw if storage.type is redis and storage.options.invalidation.referencesTTL is a negative number", () => {
+          const options = {storage: {type: "redis", options: {client: {}, invalidation: {invalidate: true, referencesTTL: -1}}}} as CreateCacheOptions
+          assert.throws(() => validateOptions(options), {message: /storage.options.invalidation.referencesTTL must be greater than 0/})
+        })
+
+        test.it("should not throw if storage.type is redis and storage.options.invalidation.referencesTTL is a positive number", () => {
+          const options = {storage: {type: "redis", options: {client: {}, invalidation: {invalidate: true, referencesTTL: 1}}}} as CreateCacheOptions
+          assert.doesNotThrow(() => validateOptions(options))
+        })
       })
     })
   })

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,7 +1,7 @@
 import type {SearchResult, SearchParams} from "@orama/orama/dist/methods/search"
 
 export type OptionsMemory = {
-  size: number
+  size?: number
   invalidation?: boolean
   log?: object
 }
@@ -17,10 +17,9 @@ type OptionsRedis = {
   log?: object
 }
 
-type StorageOptions = {
-  type: "memory" | "redis"
-  options?: OptionsMemory | OptionsRedis
-}
+export type StorageType = "memory" | "redis"
+
+export type StorageOptions = {type: Extract<StorageType, "memory">; options?: OptionsMemory} | {type: Extract<StorageType, "redis">; options: OptionsRedis}
 
 export type CreateCacheOptions = {
   ttl?: number
@@ -32,14 +31,8 @@ export type CreateCacheOptions = {
   storage?: StorageOptions
 }
 
-export type ValidatedCacheOptions = {
-  ttl: number
-  stale?: number
-  onDedupe?: (...args) => void
-  onError?: (...args) => void
-  onHit?: (key: string) => void
-  onMiss?: (key: string) => void
-  storage: StorageOptions
+export type ValidatedCacheOptions<T extends "memory" | "redis"> = Omit<CreateCacheOptions, "storage"> & {
+  storage: Required<StorageOptions & {type: T}>
 }
 
 declare module "async-cache-dedupe" {


### PR DESCRIPTION
This PR drops `Node v16` support.